### PR TITLE
Dev (#25)

### DIFF
--- a/ARM/Nordic/src/iopincfg_nrf5x.c
+++ b/ARM/Nordic/src/iopincfg_nrf5x.c
@@ -216,6 +216,7 @@ bool IOPinEnableInterrupt(int IntNo, int IntPrio, int PortNo, int PinNo, IOPINSE
     {
         NRF_GPIO_Type *reg = NRF_GPIO;
 
+
 #ifdef NRF52840_XXAA
         if (PortNo == 1)
         {
@@ -259,8 +260,7 @@ bool IOPinEnableInterrupt(int IntNo, int IntPrio, int PortNo, int PinNo, IOPINSE
     NVIC_SetPriority(GPIOTE_IRQn, IntPrio);
     NVIC_EnableIRQ(GPIOTE_IRQn);
 
-
-    return true;
+	reg->PIN_CNF[PinNo] |= (val << GPIO_PIN_CNF_DRIVE_Pos);
 }
 
 /**
@@ -335,77 +335,6 @@ void IOPinSetStrength(int PortNo, int PinNo, IOPINSTRENGTH Strength)
 	}
 
 	reg->PIN_CNF[PinNo] |= (val << GPIO_PIN_CNF_DRIVE_Pos);
-}
-
-/**
- * @brief Set I/O pin sensing option
- *
- * Some hardware allow pin sensing to wake up or active other subsystem without
- * requiring enabling interrupts. This requires the I/O already configured
- *
- * @param	PortNo : Port number (up to 32 ports)
- * 			PinNo   : Pin number (up to 32 pins)
- * 			Sense   : Sense type of event on the I/O pin
- */
-void IOPinSetSense(int PortNo, int PinNo, IOPINSENSE Sense)
-{
-	NRF_GPIO_Type *reg = NRF_GPIO;
-
-#ifdef NRF52840_XXAA
-	if (PortNo == 1)
-	{
-		reg = NRF_P1;
-	}
-
-#endif
-
-	// Clear sense
-	reg->PIN_CNF[PinNo] &= ~(GPIO_PIN_CNF_SENSE_Msk << GPIO_PIN_CNF_SENSE_Pos);
-	switch (Sense)
-	{
-		case IOPINSENSE_LOW_DISABLE:	// Disable pin sense
-			// Already done above
-			break;
-		case IOPINSENSE_LOW_TRANSITION:	// Event on falling edge
-			reg->PIN_CNF[PinNo] |= (GPIO_PIN_CNF_SENSE_Low << GPIO_PIN_CNF_SENSE_Pos);
-			break;
-		case IOPINSENSE_HIGH_TRANSITION:// Event on raising edge
-			reg->PIN_CNF[PinNo] |= (GPIO_PIN_CNF_SENSE_High << GPIO_PIN_CNF_SENSE_Pos);
-			break;
-		case IOPINSENSE_TOGGLE:			// Event on state change
-			// Not supported, use sense low for now
-			reg->PIN_CNF[PinNo] |= (3 << GPIO_PIN_CNF_SENSE_Pos);
-			break;
-	}
-}
-
-/**
- * @brief Set I/O pin drive strength option
- *
- * Some hardware allow setting pin drive strength. This requires the I/O already configured
- *
- * @param	PortNo 	: Port number (up to 32 ports)
- * 			PinNo  	: Pin number (up to 32 pins)
- * 			Strength: Pin drive strength
- */
-void IOPinSetStrength(int PortNo, int PinNo, IOPINSTRENGTH Strength)
-{
-	NRF_GPIO_Type *reg = NRF_GPIO;
-
-#ifdef NRF52840_XXAA
-	if (PortNo == 1)
-	{
-		reg = NRF_P1;
-	}
-
-#endif
-
-	reg->PIN_CNF[PinNo] &= ~(GPIO_PIN_CNF_DRIVE_Msk << GPIO_PIN_CNF_DRIVE_Pos);
-	if (Strength == IOPINSTRENGTH_STRONG)
-	{
-		// Stronger drive strength
-		reg->PIN_CNF[PinNo] |= (GPIO_PIN_CNF_DRIVE_H0H1 << GPIO_PIN_CNF_DRIVE_Pos);
-	}
 }
 
 void __WEAK GPIOTE_IRQHandler(void)


### PR DESCRIPTION
* Add pin sense & drive strength to gpio pin configuration
Combine to single iopinctrl for nRF5x serie (including nRF52840 with multiport gpio)

* More comments

* Comments

* Fixes compile errors LPC17xx
Updated iopinctrl for LPC17xx

* Add restart condition for compatibility with LPC MCU

* Fixes LPC17xx I2C interface

* Add support open drain config
improve support for gpio strength config

* Enum naming change

* optimized UART

* Loopback between 2 com port

* Python PRBS TX & RX

* Implement disconnect pin

* Add rx overun error count stats

* little cleanup OSX

* Preliminary update to Nordic SDK14

* improve delay function

* renaming

* new clock adjustment

* rename

* files moved to new location

* always inline

* location change

* Adjustment delay factor

* Add ADC device, preliminary

* uart_prbs_rx demo

* Renaming & factor adjustment

* gitignore

* Add test cases

* Comments & cleanup

* Corrected calibration hanging

* Handle DONE interrupt event

* Signed number

* fixed bad data ordering in interrupt mode

* more cleanup

* Move and renaming

* moved

* ESB DeviceIntrf

* Fixes #1
Interrupt multiple gpio pins

* SAADC example with more channels

* Fixed infinit loop introduced while doing code cleaning

* Timing adjustment for LCP11xx

* always inline

* SDK14 CMSIS update

* Update project path

* Add sections

* Move fifo to per channel
Per channel data read

* Require change for GCC version 6

* Disconnect at ~30 s issue on certain Android phone

* fixes BLE service read write config connectivity

* Update demo

* premilinary timer implementation

* Timer continued

* Preliminary nRF5x HF timer implementation

* More precision adjustment

* remove test code

* Full counting

* Add enable/disable

* Freq/period calculation adjustment

* Add low freq RTC timer to demo

* More comments and optimization

* naming

* Add default clock src

* Timer on nRF51

* remove unused code

* Flush TX FIFO before reset flag to get tx ready for transmission.

* Bad merge